### PR TITLE
Don't set HTMLTranslator, which causes conflicts

### DIFF
--- a/sphinx_sitemap/__init__.py
+++ b/sphinx_sitemap/__init__.py
@@ -24,7 +24,6 @@ def setup(app):
     )
     app.connect('html-page-context', add_html_link)
     app.connect('build-finished', create_sitemap)
-    app.set_translator('html', HTMLTranslator)
     app.sitemap_links = []
 
 


### PR DESCRIPTION
Removing this will allow the extension to work with any other extension that overrides HTMLTranslator. It's also not needed. Tested and works fine.