### PR TITLE
Support for DirectoryHTMLBuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.egg-info/
 dist/
 build/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .tox
 *.egg-info/
 dist/
+build/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,6 @@ You can now make changes to `sphinx_sitemap_dev`.
 
 ### Testing your changes
 
-1. Run `pep8` on `sphinx_sitemap_dev`:
+1. Run `pycodestyle` on `sphinx_sitemap_dev`:
 
-   ```pep8 sphinx_sitemap_dev```
+   ```pycodestyle sphinx_sitemap_dev```

--- a/sphinx_sitemap/__init__.py
+++ b/sphinx_sitemap/__init__.py
@@ -13,7 +13,6 @@
 
 import os
 import xml.etree.ElementTree as ET
-from sphinx.writers.html import HTMLTranslator
 
 
 def setup(app):

--- a/sphinx_sitemap/__init__.py
+++ b/sphinx_sitemap/__init__.py
@@ -31,6 +31,7 @@ def setup(app):
     except BaseException:
         pass
 
+    app.connect('builder-inited', record_builder_type)
     app.connect('html-page-context', add_html_link)
     app.connect('build-finished', create_sitemap)
     app.sitemap_links = []
@@ -48,6 +49,13 @@ def get_locales(app, exception):
             for locale in os.listdir(locale_dir):
                 if os.path.isdir(os.path.join(locale_dir, locale)):
                     app.locales.append(locale)
+
+
+def record_builder_type(app):
+    # builder isn't initialized in the setup so we do it here
+    # we rely on the class name, not the actual class, as it was moved 2.0.0
+    builder_class_name = getattr(app, "builder", None).__class__.__name__
+    app.is_dictionary_builder = (builder_class_name == 'DirectoryHTMLBuilder')
 
 
 def add_html_link(app, pagename, templatename, context, doctree):

--- a/sphinx_sitemap/__init__.py
+++ b/sphinx_sitemap/__init__.py
@@ -29,7 +29,7 @@ def setup(app):
             default=None,
             rebuild=False
         )
-    except:
+    except BaseException:
         pass
 
     app.connect('html-page-context', add_html_link)

--- a/sphinx_sitemap/__init__.py
+++ b/sphinx_sitemap/__init__.py
@@ -60,7 +60,18 @@ def record_builder_type(app):
 
 def add_html_link(app, pagename, templatename, context, doctree):
     """As each page is built, collect page names for the sitemap"""
-    app.sitemap_links.append(pagename + ".html")
+    if app.is_dictionary_builder:
+        if pagename == "index":
+            # root of the entire website, a special case
+            directory_pagename = ""
+        elif pagename.endswith("/index"):
+            # checking until / to avoid false positives like /funds-index
+            directory_pagename = pagename[:-6] + "/"
+        else:
+            directory_pagename = pagename + "/"
+        app.sitemap_links.append(directory_pagename)
+    else:
+        app.sitemap_links.append(pagename + ".html")
 
 
 def create_sitemap(app, exception):

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ envlist = {py36}-sphinx{12,tip}
 basepython =
     py36: python3.6
 deps =
-    pep8
+    pycodestyle
     sphinx12: Sphinx~=1.2.0
     sphinxtip: git+https://github.com/sphinx-doc/sphinx.git#egg=Sphinx-dev
 commands =
-    pep8 sphinx_sitemap/
+    pycodestyle sphinx_sitemap/


### PR DESCRIPTION
Let's imagine a project with the following documentation structure:

```
index.rst
faq.rst
downloads/index.rst
downloads/linux.rst
```

`sphinx-sitemap` would generate a sitemap with:

```
https://example.com/index.html
https://example.com/faq.html
https://example.com/downloads/index.html
https://example.com/downloads/linux.html
```

But as we are using `DirectoryHTMLBuilder`, Sphinx will actually build:

```
https://example.com/index.html
https://example.com/faq/index.html              <- wrong in sitemap
https://example.com/downloads/index.html
https://example.com/downloads/linux/index.html  <- wrong in sitemap
```

And thus, as we want to use "directory" style URLs:

```
https://example.com/
https://example.com/faq/
https://example.com/downloads/
https://example.com/downloads/linux/
```

Which the main beef of this pull request.

Additionally:
* upgrade from deprecated `pep8` to `pycodestyle`
* remove some unused code
* ignore a couple development related directories

Cheers!