### PR TITLE
[IMP] allow custom URL scheme for internationalized pages

### DIFF
--- a/sphinx_sitemap/__init__.py
+++ b/sphinx_sitemap/__init__.py
@@ -24,7 +24,7 @@ def setup(app):
     )
     app.add_config_value(
         'i18n_url_scheme',
-        default="/{lang}/{version}{link}",
+        default="{lang}/{version}{link}",
         rebuild=False
     )
 
@@ -83,6 +83,7 @@ def add_html_link(app, pagename, templatename, context, doctree):
 def create_sitemap(app, exception):
     """Generates the sitemap.xml from the collected HTML page links"""
     site_url = app.builder.config.site_url or app.builder.config.html_baseurl
+    site_url = site_url.rstrip('/') + '/'
     if not site_url:
         print("sphinx-sitemap error: neither html_baseurl nor site_url "
               "are set in conf.py. Sitemap not built.")
@@ -99,14 +100,15 @@ def create_sitemap(app, exception):
     get_locales(app, exception)
 
     if app.builder.config.version:
-        version = app.builder.config.version + '/'
+        version = app.builder.config.version.rstrip('/') + '/'
     else:
         version = app.builder.config.version
 
     for link in app.sitemap_links:
         url = ET.SubElement(root, "url")
         if app.builder.config.language is not None:
-            scheme = app.config.i18n_url_scheme or "/{lang}/{version}{link}"
+            scheme = app.config.i18n_url_scheme.lstrip('/') \
+                or "{lang}/{version}{link}"
             ET.SubElement(url, "loc").text = site_url + scheme.format(
                 lang=app.builder.config.language, version=version, link=link
             )

--- a/sphinx_sitemap/__init__.py
+++ b/sphinx_sitemap/__init__.py
@@ -24,7 +24,7 @@ def setup(app):
     )
     app.add_config_value(
         'i18n_url_scheme',
-        default="{lang}/{version}{link}",
+        default="{lang}/{version}/{link}",
         rebuild=False
     )
 
@@ -100,33 +100,29 @@ def create_sitemap(app, exception):
     get_locales(app, exception)
 
     if app.builder.config.version:
-        version = app.builder.config.version.rstrip('/') + '/'
-    else:
         version = app.builder.config.version
+    else:
+        version = "latest"
 
     for link in app.sitemap_links:
         url = ET.SubElement(root, "url")
-        if app.builder.config.language is not None:
-            scheme = app.config.i18n_url_scheme.lstrip('/') \
-                or "{lang}/{version}{link}"
-            ET.SubElement(url, "loc").text = site_url + scheme.format(
-                lang=app.builder.config.language, version=version, link=link
-            )
-            if len(app.locales) > 0:
-                for lang in app.locales:
-                    linktag = ET.SubElement(
-                        url,
-                        "{http://www.w3.org/1999/xhtml}link"
-                    )
-                    linktag.set("rel", "alternate")
-                    linktag.set("hreflang", lang)
-                    linktag.set("href", site_url + scheme.format(
-                        lang=lang, version=version, link=link
-                    ))
-        elif app.builder.config.version:
-            ET.SubElement(url, "loc").text = site_url + version + link
-        else:
-            ET.SubElement(url, "loc").text = site_url + link
+        scheme = app.config.i18n_url_scheme
+        lang = app.builder.config.language \
+            or "en"
+        ET.SubElement(url, "loc").text = site_url + scheme.format(
+            lang=lang, version=version, link=link
+        )
+        if len(app.locales) > 0:
+            for lang in app.locales:
+                linktag = ET.SubElement(
+                    url,
+                    "{http://www.w3.org/1999/xhtml}link"
+                )
+                linktag.set("rel", "alternate")
+                linktag.set("hreflang", lang)
+                linktag.set("href", site_url + scheme.format(
+                    lang=lang, version=version, link=link
+                ))
 
     filename = app.outdir + "/sitemap.xml"
     ET.ElementTree(root).write(filename,

--- a/sphinx_sitemap/__init__.py
+++ b/sphinx_sitemap/__init__.py
@@ -22,6 +22,12 @@ def setup(app):
         default=None,
         rebuild=False
     )
+    app.add_config_value(
+        'i18n_url_scheme',
+        default="/{lang}/{version}{link}",
+        rebuild=False
+    )
+
     try:
         app.add_config_value(
             'html_baseurl',
@@ -100,8 +106,10 @@ def create_sitemap(app, exception):
     for link in app.sitemap_links:
         url = ET.SubElement(root, "url")
         if app.builder.config.language is not None:
-            ET.SubElement(url, "loc").text = site_url + \
-                  app.builder.config.language + '/' + version + link
+            scheme = app.config.i18n_url_scheme or "/{lang}/{version}{link}"
+            ET.SubElement(url, "loc").text = site_url + scheme.format(
+                lang=app.builder.config.language, version=version, link=link
+            )
             if len(app.locales) > 0:
                 for lang in app.locales:
                     linktag = ET.SubElement(
@@ -110,7 +118,9 @@ def create_sitemap(app, exception):
                     )
                     linktag.set("rel", "alternate")
                     linktag.set("hreflang", lang)
-                    linktag.set("href", site_url + lang + '/' + version + link)
+                    linktag.set("href", site_url + scheme.format(
+                        lang=lang, version=version, link=link
+                    ))
         elif app.builder.config.version:
             ET.SubElement(url, "loc").text = site_url + version + link
         else:


### PR DESCRIPTION
Allowing to use a custom i18n_url_scheme parameter.
Before this commit, the URLs were forced to use the format
`<site>/<lang>/<version>/<link>` which is the format used by RTD but
some may use a different one.

Fixes jdillard/sphinx-sitemap#22