### PR TITLE
sitemap_locales option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,9 +52,34 @@ Multilingual Configuration
 For multilingual sitemaps, you have to generate a sitemap per language/locale
 and then manually add their locations to a `sitemapindex`_ file.
 
-The extension will look at the `language`_ config value for the current language
-being built, and the `locale_dirs`_ value for the directory for alternate
-languages, so make sure those are set.
+Primary language is `language`_ config value. Alternative languages are either
+manually set by ``sitemap_locales`` option or auto-detected by the extension from
+the `locale_dirs`_ config value, so make sure one of those is set.
+
+``sitemap_locales`` configuration is handy you want to list in the sitemap only some
+of existing locales, if third-party extension adds locale_dirs to Sphinx for the
+languages which you don't support in your docs, or to "exclude" primary language
+(`language`_). For example, if primary language is en, sitemap will contain it twice::
+
+    <?xml version="1.0" encoding="utf-8"?>
+      <urlset xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+        <url>
+          <loc>https://my-site.com/docs/en/index.html</loc>
+          <xhtml:link href="https://my-site.com/docs/es/index.html" hreflang="es" rel="alternate"/>
+          <xhtml:link href="https://my-site.com/docs/fr/index.html" hreflang="fr" rel="alternate"/>
+          <xhtml:link href="https://my-site.com/docs/en/index.html" hreflang="en" rel="alternate"/>
+        </url>
+        <url>
+            <loc>https://my-site.com/docs/en/about.html</loc>
+            <xhtml:link href="https://my-site.com/docs/es/about.html" hreflang="es" rel="alternate"/>
+            <xhtml:link href="https://my-site.com/docs/fr/about.html" hreflang="fr" rel="alternate"/>
+            <xhtml:link href="https://my-site.com/docs/en/about.html" hreflang="en" rel="alternate"/>
+        </url>
+      </urlset>
+
+If you limit sitemap::
+
+    sitemap_locales = ['es', 'fr']
 
 The end result is something like the following for each language/version build::
 
@@ -64,13 +89,27 @@ The end result is something like the following for each language/version build::
       <loc>https://my-site.com/docs/en/index.html</loc>
       <xhtml:link href="https://my-site.com/docs/es/index.html" hreflang="es" rel="alternate"/>
       <xhtml:link href="https://my-site.com/docs/fr/index.html" hreflang="fr" rel="alternate"/>
-      <xhtml:link href="https://my-site.com/docs/en/index.html" hreflang="en" rel="alternate"/>
     </url>
     <url>
       <loc>https://my-site.com/docs/en/about.html</loc>
       <xhtml:link href="https://my-site.com/docs/es/about.html" hreflang="es" rel="alternate"/>
       <xhtml:link href="https://my-site.com/docs/fr/about.html" hreflang="fr" rel="alternate"/>
-      <xhtml:link href="https://my-site.com/docs/en/about.html" hreflang="en" rel="alternate"/>
+    </url>
+  </urlset>
+
+If you set special value ``[None]``::
+
+    sitemap_locales = [None]
+
+only primary language is generated::
+
+  <?xml version="1.0" encoding="utf-8"?>
+  <urlset xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+      <loc>https://my-site.com/docs/en/index.html</loc>
+    </url>
+    <url>
+      <loc>https://my-site.com/docs/en/about.html</loc>
     </url>
   </urlset>
 

--- a/sphinx_sitemap/__init__.py
+++ b/sphinx_sitemap/__init__.py
@@ -27,6 +27,11 @@ def setup(app):
         default="{lang}{version}{link}",
         rebuild=False
     )
+    app.add_config_value(
+        'sitemap_locales',
+        default=None,
+        rebuild=False
+    )
 
     try:
         app.add_config_value(
@@ -50,6 +55,21 @@ def setup(app):
 
 
 def get_locales(app, exception):
+    # Manually configured list of locales
+    sitemap_locales = app.builder.config.sitemap_locales
+    if sitemap_locales:
+        # special value to add nothing -> use primary language only
+        if sitemap_locales == [None]:
+            return
+
+        # otherwise, add each locale
+        for locale in sitemap_locales:
+            # skip primary language
+            if locale != app.builder.config.language:
+                app.locales.append(locale)
+        return
+
+    # Or autodetect
     for locale_dir in app.builder.config.locale_dirs:
         locale_dir = os.path.join(app.confdir, locale_dir)
         if os.path.isdir(locale_dir):


### PR DESCRIPTION
I propose to add the `sitemap_locales` configuration option to manually set locales that will show in the sitemap as alternates to page.

I've started to use sphinx-sitemap for my blog at https://blog.documatt.com. It's a single language and likely will stay. It's Sphinx with Ablog extension for blogging. It's a great extension that comes with many supported locales like Chinese, Korean, Spain, etc.

Unfortunately, it means that if another extension like sphinx-sitemap asks for `app.builder.config.locale_dirs`, the result is a long list of locale_dirs. Former `get_locales()` will then result in the same long list of locales. But they come from third-party extension!

So I add the `sitemap_locales` option to manually override locales which I need/want to list in sitemaps. By default, nothing changed (autodetection will take place).

But I can limit alternate URLs (e.g. `sitemap_locales = ['es', 'fr']`) or completely turn them off (`sitemap_locales = [None]`)