### PR TITLE
Follow correct format for multilingual sitemaps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,10 +133,12 @@ The end result is something like the following for each language/version build::
     <url>
       <loc>https://my-site.com/docs/en/index.html</loc>
       <xhtml:link href="https://my-site.com/docs/es/index.html" hreflang="es" rel="alternate"/>
+      <xhtml:link href="https://my-site.com/docs/en/index.html" hreflang="en" rel="alternate"/>
     </url>
     <url>
       <loc>https://my-site.com/docs/en/about.html</loc>
       <xhtml:link href="https://my-site.com/docs/es/about.html" hreflang="es" rel="alternate"/>
+      <xhtml:link href="https://my-site.com/docs/en/about.html" hreflang="en" rel="alternate"/>
     </url>
   </urlset>
 

--- a/sphinx_sitemap/__init__.py
+++ b/sphinx_sitemap/__init__.py
@@ -55,9 +55,7 @@ def get_locales(app, exception):
 
         # otherwise, add each locale
         for locale in sitemap_locales:
-            # skip primary language
-            if locale != app.builder.config.language:
-                app.locales.append(locale)
+            app.locales.append(locale)
         return
 
     # Or autodetect


### PR DESCRIPTION
## Summary of Changes

- Remove check for current language so that multilingual sitemap's follow [proper formatting](https://developers.google.com/search/docs/advanced/crawling/localized-versions#sitemap).
- Fix README sitemap example.

Closes https://github.com/jdillard/sphinx-sitemap/issues/30