### PR TITLE
Use logging for all logging messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Changelog
 * Add testing infrastructure
   [#41](https://github.com/jdillard/sphinx-sitemap/pull/41)
   [#42](https://github.com/jdillard/sphinx-sitemap/pull/42)
+* Use logging for all logging messages
+  [#40](https://github.com/jdillard/sphinx-sitemap/pull/40)
 
 2.2.1
 -----

--- a/sphinx_sitemap/__init__.py
+++ b/sphinx_sitemap/__init__.py
@@ -14,7 +14,11 @@
 import os
 import xml.etree.ElementTree as ET
 
+from sphinx.util.logging import getLogger
+
 __version__ = "2.3.0"
+
+logger = getLogger(__name__)
 
 
 def setup(app):
@@ -108,8 +112,9 @@ def create_sitemap(app, exception):
     if site_url:
         site_url.rstrip("/") + "/"
     else:
-        logger.error(
-            "sphinx-sitemap: neither html_baseurl nor site_url are set in conf.py. Sitemap not built.",
+        logger.warning(
+            "sphinx-sitemap: neither html_baseurl nor site_url are set in conf.py."
+            "Sitemap not built.",
             type="sitemap",
             subtype="configuration",
         )
@@ -117,7 +122,7 @@ def create_sitemap(app, exception):
 
     if not app.sitemap_links:
         logger.info(
-            "sphinx-sitemap:  No pages generated for %s" % app.config.sitemap_filename,
+            "sphinx-sitemap: No pages generated for %s" % app.config.sitemap_filename,
             type="sitemap",
             subtype="information",
         )
@@ -163,7 +168,9 @@ def create_sitemap(app, exception):
         filename, xml_declaration=True, encoding="utf-8", method="xml"
     )
 
-    logger.info("sphinx-sitemap: %s was generated for URL %s in %s" % (
-        app.config.sitemap_filename, site_url, filename),
+    logger.info(
+        "sphinx-sitemap: %s was generated for URL %s in %s"
+        % (app.config.sitemap_filename, site_url, filename),
         type="sitemap",
-        subtype="info",)
+        subtype="information",
+    )

--- a/sphinx_sitemap/__init__.py
+++ b/sphinx_sitemap/__init__.py
@@ -105,17 +105,21 @@ def add_html_link(app, pagename, templatename, context, doctree):
 def create_sitemap(app, exception):
     """Generates the sitemap.xml from the collected HTML page links"""
     site_url = app.builder.config.site_url or app.builder.config.html_baseurl
-    site_url = site_url.rstrip("/") + "/"
-    if not site_url:
-        print(
-            "sphinx-sitemap error: neither html_baseurl nor site_url "
-            "are set in conf.py. Sitemap not built."
+    if site_url:
+        site_url.rstrip("/") + "/"
+    else:
+        logger.error(
+            "sphinx-sitemap: neither html_baseurl nor site_url are set in conf.py. Sitemap not built.",
+            type="sitemap",
+            subtype="configuration",
         )
         return
+
     if not app.sitemap_links:
-        print(
-            "sphinx-sitemap warning: No pages generated for %s"
-            % app.config.sitemap_filename
+        logger.info(
+            "sphinx-sitemap:  No pages generated for %s" % app.config.sitemap_filename,
+            type="sitemap",
+            subtype="information",
         )
         return
 
@@ -158,7 +162,8 @@ def create_sitemap(app, exception):
     ET.ElementTree(root).write(
         filename, xml_declaration=True, encoding="utf-8", method="xml"
     )
-    print(
-        "%s was generated for URL %s in %s"
-        % (app.config.sitemap_filename, site_url, filename)
-    )
+
+    logger.info("sphinx-sitemap: %s was generated for URL %s in %s" % (
+        app.config.sitemap_filename, site_url, filename),
+        type="sitemap",
+        subtype="info",)


### PR DESCRIPTION
## Summary of Changes

- Use logging for all logging messages (instead of `print`)