### PR TITLE
Add python 3.10 tests and remove flake8 test from tox

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8',  '3.9']
+        python-version: ['3.7', '3.8',  '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python versions

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{7,8,9}-sphinx{2,3,4,5,last}, flake8
+envlist = py3{7,8,9,10}-sphinx{2,3,4,5,last}, flake8
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,9 @@
 [tox]
-envlist = py3{7,8,9,10}-sphinx{2,3,4,5,last}, flake8
+envlist =
+    py3{7,8,9}-sphinx{2,3,4,5,last}
+    # Python 3.10 is unsuppoted below Sphinx4
+    # See https://github.com/sphinx-doc/sphinx/issues/9816
+    py3{10}-sphinx{4,5,last}
 
 [testenv]
 deps =
@@ -13,10 +17,6 @@ deps =
     sphinxlast: Sphinx
 commands =
     pytest -W ignore::DeprecationWarning
-
-[testenv:flake8]
-deps = flake8
-commands = flake8 sphinx_sitemap tests
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
## Summary of Changes

- Add python 3.10 tests
- Remove `flake8` test since it was made redundant with `pre-commit`