### PR TITLE
:sparkles: NEW: Add support for parallel mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ also licensed under the MIT license.
     :target: https://pepy.tech/project/sphinx-sitemap
 .. |Code style: Black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
    :target: https://github.com/psf/black
-.. |Parallel Safe| image:: https://img.shields.io/badge/parallel%20safe-False-red
+.. |Parallel Safe| image:: https://img.shields.io/badge/parallel%20safe-true-green
    :target: #
 .. |Docs Build| image:: https://readthedocs.org/projects/sphinx-sitemap/badge/?version=latest
    :target: https://sphinx-sitemap.readthedocs.io/en/latest/?badge=latest

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ also licensed under the MIT license.
     :target: https://pepy.tech/project/sphinx-sitemap
 .. |Code style: Black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
    :target: https://github.com/psf/black
-.. |Parallel Safe| image:: https://img.shields.io/badge/parallel%20safe-true-green
+.. |Parallel Safe| image:: https://img.shields.io/badge/parallel%20safe-true-brightgreen
    :target: #
 .. |Docs Build| image:: https://readthedocs.org/projects/sphinx-sitemap/badge/?version=latest
    :target: https://sphinx-sitemap.readthedocs.io/en/latest/?badge=latest

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-2.3.1
+2.4.0
 -----
 
 *Release date: TBD*
@@ -10,6 +10,8 @@ Changelog
   `#45 <https://github.com/jdillard/sphinx-sitemap/pull/45>`_
 * General code clean up
   `#46 <https://github.com/jdillard/sphinx-sitemap/pull/46>`_
+* Add support for parallel mode
+  `#47 <https://github.com/jdillard/sphinx-sitemap/pull/47>`_
 
 2.3.0
 -----

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,7 +66,7 @@ See :doc:`configuration` for more information about how to use **sphinx-sitemap*
     :target: https://pepy.tech/project/sphinx-sitemap
 .. |Code style: Black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
    :target: https://github.com/psf/black
-.. |Parallel Safe| image:: https://img.shields.io/badge/parallel%20safe-true-red
+.. |Parallel Safe| image:: https://img.shields.io/badge/parallel%20safe-true-brightgreen
    :target: #
 .. |Docs Build| image:: https://readthedocs.org/projects/sphinx-sitemap/badge/?version=latest
    :target: https://sphinx-sitemap.readthedocs.io/en/latest/?badge=latest

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,7 +66,7 @@ See :doc:`configuration` for more information about how to use **sphinx-sitemap*
     :target: https://pepy.tech/project/sphinx-sitemap
 .. |Code style: Black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
    :target: https://github.com/psf/black
-.. |Parallel Safe| image:: https://img.shields.io/badge/parallel%20safe-False-red
+.. |Parallel Safe| image:: https://img.shields.io/badge/parallel%20safe-true-red
    :target: #
 .. |Docs Build| image:: https://readthedocs.org/projects/sphinx-sitemap/badge/?version=latest
    :target: https://sphinx-sitemap.readthedocs.io/en/latest/?badge=latest

--- a/tests/roots/test-root/dolor.rst
+++ b/tests/roots/test-root/dolor.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+Dolor
+=====
+
+This is the dolor page

--- a/tests/roots/test-root/elitr.rst
+++ b/tests/roots/test-root/elitr.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+Elitr
+=====
+
+This is the elitr page

--- a/tests/roots/test-root/ipsum.rst
+++ b/tests/roots/test-root/ipsum.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+Ipsum
+=====
+
+This is the ipsum page

--- a/tests/roots/test-root/lorem.rst
+++ b/tests/roots/test-root/lorem.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+Lorem
+=====
+
+This is the lorem page

--- a/tests/test_parallel_mode.py
+++ b/tests/test_parallel_mode.py
@@ -10,6 +10,7 @@ import pytest
 )
 def test_parallel(app, status, warning):
     app.parallel = 2
+    app.warningiserror = True
     app.build()
     assert "sitemap.xml" in app.outdir.listdir()
     doc = etree.parse(app.outdir / "sitemap.xml")

--- a/tests/test_parallel_mode.py
+++ b/tests/test_parallel_mode.py
@@ -8,7 +8,8 @@ import pytest
     freshenv=True,
     confoverrides={"html_baseurl": "https://example.org/docs/", "language": "en"},
 )
-def test_simple(app, status, warning):
+def test_parallel(app, status, warning):
+    app.parallel = 2
     app.build()
     assert "sitemap.xml" in app.outdir.listdir()
     doc = etree.parse(app.outdir / "sitemap.xml")
@@ -31,3 +32,4 @@ def test_simple(app, status, warning):
             "search",
         ]
     }
+    assert not warning.getvalue()

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -9,6 +9,7 @@ import pytest
     confoverrides={"html_baseurl": "https://example.org/docs/", "language": "en"},
 )
 def test_simple(app, status, warning):
+    app.warningiserror = True
     app.build()
     assert "sitemap.xml" in app.outdir.listdir()
     doc = etree.parse(app.outdir / "sitemap.xml")


### PR DESCRIPTION
## Summary of Changes

- Add support for parallel mode

## Notes

Huge shout-out to @xmo-odoo for https://github.com/jdillard/sphinx-sitemap/pull/29 (closed so couldn't merge).

Future improvements to detecting when parallel mode is turned on could be made, as mentioned in the PR:

> This is achieved by storing a queue in the env so the "write" workers can shove page names in there (sadly multiprocessing.Queue did not work as it apparently doesn't like the way the workers are created), and create_sitemap can then pop all that from the queue.
>
> Anyway there's a bit of an issue here, probably not a huge one because sitemap is only invoked once per document (not hundreds of times per), but the multiprocessing queue is always created and possibly somewhat heavy (it's at least a separate process, plus whatever the proxies use to communicate with the subprocess), but while Builder has a parallel_ok flag that flag is only set during build(), which comes later than record_builder_type.
>
> The only option I can see (aside from Sphinx being updated to resolve this earlier) is to copy the implementation details of parallel_ok in the extension and hope they don't change too much in the future, using that to decide between the seq and the parallel sitemap_links implementations, and that's gross.
>
> Even hooking into one of the events between the reading and writing phase would not work: parallel_ok is actually set after env-check-consistency, and there doesn't seem to be any sequential event afterwards.

Potentially better support from Sphinx outlined here: https://github.com/sphinx-doc/sphinx/issues/9480