### PR TITLE
:bug: FIX: Fix wheel includes so they don't include docs and tests

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,7 +16,7 @@ Changelog
   `#48 <https://github.com/jdillard/sphinx-sitemap/pull/48>`_
 * Add vale support for docs
   `#49 <https://github.com/jdillard/sphinx-sitemap/pull/49>`_
-* Fix wheel includes
+* Fix wheel includes so they don't include docs and tests
   `#51 <https://github.com/jdillard/sphinx-sitemap/pull/51>`_
 
 2.3.0

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,8 @@ Changelog
   `#48 <https://github.com/jdillard/sphinx-sitemap/pull/48>`_
 * Add vale support for docs
   `#49 <https://github.com/jdillard/sphinx-sitemap/pull/49>`_
+* Fix wheel includes
+  `#51 <https://github.com/jdillard/sphinx-sitemap/pull/51>`_
 
 2.3.0
 -----

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,5 @@
 tox
+build
 pre-commit
 flake8
 sphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,7 @@ version = attr: sphinx_sitemap.__version__
 packages = find_namespace:
 install_requires =
     sphinx>=1.2
+
+[options.packages.find]
+where = .
+include = sphinx_sitemap*


### PR DESCRIPTION
 The contents of `.whl` archive no longer include the `tests` and `docs` directory content:

```console
  Length      Date    Time    Name
---------  ---------- -----   ----
     5969  2022-12-26 01:18   sphinx_sitemap/__init__.py
     1070  2022-12-26 01:27   sphinx_sitemap-2.4.0.dist-info/LICENSE
     2681  2022-12-26 01:27   sphinx_sitemap-2.4.0.dist-info/METADATA
       92  2022-12-26 01:27   sphinx_sitemap-2.4.0.dist-info/WHEEL
       15  2022-12-26 01:27   sphinx_sitemap-2.4.0.dist-info/top_level.txt
      504  2022-12-26 01:27   sphinx_sitemap-2.4.0.dist-info/RECORD
---------                     -------
    10331                     6 files
```

## Summary of Changes

- Fix wheel includes
- Add `build` package

Closes https://github.com/jdillard/sphinx-sitemap/issues/50