### PR TITLE
:wrench: MAINT: Remove ignore flag from pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     sphinx6: Sphinx~=6.0
     sphinxlast: Sphinx
 commands =
-    pytest -W ignore::DeprecationWarning
+    pytest
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
Stop ignoring deprecation warnings in pytest