### PR TITLE
:wrench: MAINT: Fix deprecated sphinx.testing.path

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,15 @@
 Changelog
 =========
 
+2.5.2
+-----
+
+*Release date: TBD*
+
+* |:wrench:| MAINT: Fix deprecated sphinx.testing.path
+  `#83 <https://github.com/jdillard/sphinx-sitemap/pull/83>`_
+* Drop test support for Sphinx 2, 3, and 4.
+
 2.5.1
 -----
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+import sphinx
 
 pytest_plugins = "sphinx.testing.fixtures"
 # Exclude 'roots' dirs for pytest test collector

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from sphinx.testing.path import path
+from os import path
 
 pytest_plugins = "sphinx.testing.fixtures"
 # Exclude 'roots' dirs for pytest test collector
@@ -14,4 +14,6 @@ def pytest_configure(config):
 
 @pytest.fixture(scope="session")
 def rootdir():
-    return path(__file__).parent.abspath() / "roots"
+    current_script_path = path.abspath(__file__)
+    parent_directory = path.abspath(path.dirname(current_script_path))
+    return parent_directory / "roots"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
-import pytest
 from os import path
+
+import pytest
 
 pytest_plugins = "sphinx.testing.fixtures"
 # Exclude 'roots' dirs for pytest test collector

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,4 +17,4 @@ def pytest_configure(config):
 def rootdir():
     current_script_path = path.abspath(__file__)
     parent_directory = path.abspath(path.dirname(current_script_path))
-    return parent_directory / "roots"
+    return path.join(parent_directory, "roots")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
-from os import path
+from pathlib import Path
 
+import os
 import pytest
 
 pytest_plugins = "sphinx.testing.fixtures"
@@ -16,5 +17,5 @@ def pytest_configure(config):
 @pytest.fixture(scope="session")
 def rootdir():
     current_script_path = path.abspath(__file__)
-    parent_directory = path.abspath(path.dirname(current_script_path))
-    return path.join(parent_directory, "roots")
+    parent_directory = os.path.abspath(path.dirname(current_script_path))
+    return Path(os.path.join(parent_directory, "roots"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
+import os
 from pathlib import Path
 
-import os
 import pytest
 
 pytest_plugins = "sphinx.testing.fixtures"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,6 @@ def rootdir():
     if sphinx.version_info[:2] < (7, 2):
         from sphinx.testing.path import path
 
-        return path(__file__).parent.abspath() / 'roots'
+        return path(__file__).parent.abspath() / "roots"
 
-    return Path(__file__).resolve().parent / 'roots'
+    return Path(__file__).resolve().parent / "roots"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import pytest
@@ -16,6 +15,9 @@ def pytest_configure(config):
 
 @pytest.fixture(scope="session")
 def rootdir():
-    current_script_path = os.path.abspath(__file__)
-    parent_directory = os.path.abspath(os.path.dirname(current_script_path))
-    return Path(os.path.join(parent_directory, "roots"))
+    if sphinx.version_info[:2] < (7, 2):
+        from sphinx.testing.path import path
+
+        return path(__file__).parent.abspath() / 'roots'
+
+    return Path(__file__).resolve().parent / 'roots'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,6 @@ def pytest_configure(config):
 
 @pytest.fixture(scope="session")
 def rootdir():
-    current_script_path = path.abspath(__file__)
-    parent_directory = os.path.abspath(path.dirname(current_script_path))
+    current_script_path = os.path.abspath(__file__)
+    parent_directory = os.path.abspath(os.path.dirname(current_script_path))
     return Path(os.path.join(parent_directory, "roots"))

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist =
 deps =
     pytest
     sphinx4: Sphinx>=4.0,<4.5.0
+    sphinx4: sphinxcontrib-applehelp<1.0.5
     sphinx5: Sphinx~=5.0
     sphinx6: Sphinx~=6.0
     sphinxlast: Sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     sphinx4: Sphinx~=4.0
     sphinx4: sphinxcontrib-applehelp<1.0.8
     sphinx4: sphinxcontrib-devhelp<1.0.6
+    sphinx4: sphinxcontrib-htmlhelp<2.0.5
     sphinx5: Sphinx~=5.0
     sphinx6: Sphinx~=6.0
     sphinxlast: Sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     sphinx2: jinja2<3.1
     sphinx3: Sphinx~=3.0
     sphinx3: jinja2<3.1
-    sphinx4: Sphinx~=4.0
+    sphinx4: Sphinx>=4.0,<4.5.0
     sphinx5: Sphinx~=5.0
     sphinx6: Sphinx~=6.0
     sphinxlast: Sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 envlist =
-    py37-sphinx{4,5}
+    py37-sphinx5
     # Python 3.7 unsupported above Sphinx 6
-    py3{8,9}-sphinx{4,5,6,last}
+    py3{8,9}-sphinx{5,6,last}
     # Python 3.10 is unsupported below Sphinx4
     # See https://github.com/sphinx-doc/sphinx/issues/9816
-    py3{10,11}-sphinx{4,5,6,last}
+    py3{10,11}-sphinx{5,6,last}
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py37-sphinx{2,3,4,5}
+    py37-sphinx{4,5}
     # Python 3.7 unsupported above Sphinx 6
-    py3{8,9}-sphinx{2,3,4,5,6,last}
+    py3{8,9}-sphinx{4,5,6,last}
     # Python 3.10 is unsupported below Sphinx4
     # See https://github.com/sphinx-doc/sphinx/issues/9816
     py3{10,11}-sphinx{4,5,6,last}

--- a/tox.ini
+++ b/tox.ini
@@ -10,10 +10,6 @@ envlist =
 [testenv]
 deps =
     pytest
-    sphinx4: Sphinx~=4.0
-    sphinx4: sphinxcontrib-applehelp<1.0.8
-    sphinx4: sphinxcontrib-devhelp<1.0.6
-    sphinx4: sphinxcontrib-htmlhelp<2.0.5
     sphinx5: Sphinx~=5.0
     sphinx6: Sphinx~=6.0
     sphinxlast: Sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,9 @@ envlist =
 [testenv]
 deps =
     pytest
-    sphinx4: Sphinx>=4.0,<4.5.0
-    sphinx4: sphinxcontrib-applehelp<1.0.5
+    sphinx4: Sphinx~=4.0
+    sphinx4: sphinxcontrib-applehelp<1.0.8
+    sphinx4: sphinxcontrib-devhelp<1.0.6
     sphinx5: Sphinx~=5.0
     sphinx6: Sphinx~=6.0
     sphinxlast: Sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -10,10 +10,6 @@ envlist =
 [testenv]
 deps =
     pytest
-    sphinx2: Sphinx~=2.0
-    sphinx2: jinja2<3.1
-    sphinx3: Sphinx~=3.0
-    sphinx3: jinja2<3.1
     sphinx4: Sphinx>=4.0,<4.5.0
     sphinx5: Sphinx~=5.0
     sphinx6: Sphinx~=6.0


### PR DESCRIPTION
## Problem
```
sphinx-sitemap/tests/conftest.py:2: RemovedInSphinx90Warning: 'sphinx.testing.path' is deprecated. Use 'os.path' or 'pathlib'
```
## Summary of changes

- Replace `sphinx.testing.path` with `Path`
- Drop test support for Sphinx 2, 3 and 4.