### PR TITLE
NEW: Added sitemap_suffix_included to better work with Cloudflare Pages and search engines

### DIFF
--- a/docs/source/advanced-configuration.rst
+++ b/docs/source/advanced-configuration.rst
@@ -39,6 +39,20 @@ Set :confval:`sitemap_filename` in **conf.py** to the desired filename, for exam
 
    sitemap_filename = "sitemap.xml"
 
+.. _configuration_including_suffix:
+
+Including File Extensions
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Set :confval:`sitemap_suffix_included` in **conf.py** to include/exclude file extensions in URLs, for example:
+
+.. code-block:: python
+
+   sitemap_suffix_included = True
+
+.. note:: The default value is ``True``. Set to ``False`` to suppress file extensions in URLs so that the sitemap
+   generated works better with service providers like Cloudflare Pages.
+
 Version Support
 ^^^^^^^^^^^^^^^
 

--- a/docs/source/configuration-values.rst
+++ b/docs/source/configuration-values.rst
@@ -32,3 +32,11 @@ Another line to :math:`test two two`
    See :ref:`configuration_supporting_multiple_languages` for more information.
 
    .. versionadded:: 2.2.0
+
+.. confval:: sitemap_suffix_included
+
+   Whether to include file extensions in URL. Default is ``True``.
+
+   See :ref:`configuration_including_suffix` for more information.
+
+   .. versionadded:: 2.5.2

--- a/sphinx_sitemap/__init__.py
+++ b/sphinx_sitemap/__init__.py
@@ -42,6 +42,8 @@ def setup(app: Sphinx) -> Dict[str, Any]:
 
     app.add_config_value("sitemap_filename", default="sitemap.xml", rebuild="")
 
+    app.add_config_value("sitemap_suffix_included", default=True, rebuild="")
+
     try:
         app.add_config_value("html_baseurl", default=None, rebuild="")
     except BaseException:
@@ -141,7 +143,7 @@ def add_html_link(app: Sphinx, pagename: str, templatename, context, doctree):
         else:
             sitemap_link = pagename + "/"
     else:
-        sitemap_link = pagename + file_suffix
+        sitemap_link = (pagename + file_suffix) if app.config.sitemap_suffix_included else pagename
 
     env.app.sitemap_links.put(sitemap_link)  # type: ignore
 

--- a/sphinx_sitemap/__init__.py
+++ b/sphinx_sitemap/__init__.py
@@ -143,7 +143,9 @@ def add_html_link(app: Sphinx, pagename: str, templatename, context, doctree):
         else:
             sitemap_link = pagename + "/"
     else:
-        sitemap_link = (pagename + file_suffix) if app.config.sitemap_suffix_included else pagename
+        sitemap_link = (
+            (pagename + file_suffix) if app.config.sitemap_suffix_included else pagename
+        )
 
     env.app.sitemap_links.put(sitemap_link)  # type: ignore
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -99,3 +99,38 @@ def test_simple_dirhtml(app, status, warning):
             "search/",
         ]
     }
+
+
+@pytest.mark.sphinx(
+    "html",
+    freshenv=True,
+    confoverrides={
+        "html_baseurl": "https://example.org/docs/",
+        "language": "en",
+        "sitemap_suffix_included": False,
+    },
+)
+def test_sitemap_suffix_included(app, status, warning):
+    app.warningiserror = True
+    app.build()
+    assert "sitemap.xml" in os.listdir(app.outdir)
+    doc = etree.parse(app.outdir / "sitemap.xml")
+    urls = {
+        e.text
+        for e in doc.findall(".//{http://www.sitemaps.org/schemas/sitemap/0.9}loc")
+    }
+
+    assert urls == {
+        f"https://example.org/docs/en/{d}"
+        for d in [
+            "index",
+            "foo",
+            "bar",
+            "lorem",
+            "ipsum",
+            "dolor",
+            "elitr",
+            "genindex",
+            "search",
+        ]
+    }


### PR DESCRIPTION
When hosting a Sphinx project on Cloudflare Pages with default suffix `.html`, a very annoying fact is that the Cloudflare platform generates 301 responses to remove the suffix.

Search engines (especially Google) dislike such redirection and refuse to index such pages, and that makes the generated sitemap less useful for SEO.

Thus, this pull request proposes a new setting `sitemap_suffix_included` to control whether `.html` should be written to `sitemap.xml`. The default value is set to `True` to keep current behavior. When `False` is set, the generated `sitemap.xml` works well with Cloudflare and SEO.