### PR TITLE
:sparkles: NEW: Add sitemap_excludes configuration

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -57,7 +57,7 @@ jobs:
           python -m pip install .
       - name: Run Tests for ${{ matrix.python-version }}
         run: |
-          python -m tox
+          python -m tox -v
   vale:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,15 +20,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8',  '3.9', '3.10', '3.11']
+        python-version: ['3.8',  '3.9', '3.10', '3.11', '3.12']
         sphinx-version: ['']
         include:
-          - python-version: '3.11'
+          - python-version: '3.12'
             sphinx-version: 'dev'
-          - python-version: '3.10'
+          - python-version: '3.11'
             sphinx-version: '7'
-          - python-version: '3.9'
+          - python-version: '3.10'
             sphinx-version: '6'
+          - python-version: '3.9'
+            sphinx-version: '5'
           - python-version: '3.8'
             sphinx-version: '5'
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8',  '3.9', '3.10', '3.11']
+        python-version: ['3.8',  '3.9', '3.10', '3.11']
         sphinx-version: ['']
         include:
           - python-version: '3.11'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -57,7 +57,7 @@ jobs:
           python -m pip install .
       - name: Run Tests for ${{ matrix.python-version }}
         run: |
-          python -m tox -v
+          python -m tox
   vale:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@
 Changelog
 =========
 
-2.5.2
+2.6.0
 -----
 
 *Release date: TBD*
@@ -11,6 +11,7 @@ Changelog
 * |:wrench:| MAINT: Fix deprecated sphinx.testing.path
   `#83 <https://github.com/jdillard/sphinx-sitemap/pull/83>`_
 * Drop test support for Sphinx 2, 3, and 4.
+* |:sparkles:| NEW: Add sitemap_excludes configuration
 
 2.5.1
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Changelog
 
 * |:wrench:| MAINT: Fix deprecated sphinx.testing.path
   `#83 <https://github.com/jdillard/sphinx-sitemap/pull/83>`_
-* Drop test support for Sphinx 2, 3, and 4.
+* Drop test support for Python 3.7 and Sphinx 2, 3, and 4.
 * |:sparkles:| NEW: Add sitemap_excludes configuration
   `#91 <https://github.com/jdillard/sphinx-sitemap/pull/91>`_
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Changelog
   `#83 <https://github.com/jdillard/sphinx-sitemap/pull/83>`_
 * Drop test support for Sphinx 2, 3, and 4.
 * |:sparkles:| NEW: Add sitemap_excludes configuration
+  `#91 <https://github.com/jdillard/sphinx-sitemap/pull/91>`_
 
 2.5.1
 -----

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,6 @@ furo
 esbonio
 sphinx-contributors
 sphinx
--e ../../sphinx-sitemap
+sphinx-sitemap
 sphinxemoji
 sphinxext-opengraph

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,6 @@ furo
 esbonio
 sphinx-contributors
 sphinx
-sphinx-sitemap
+-e ../../sphinx-sitemap
 sphinxemoji
 sphinxext-opengraph

--- a/docs/source/advanced-configuration.rst
+++ b/docs/source/advanced-configuration.rst
@@ -127,7 +127,7 @@ For multilingual sitemaps, generate a sitemap per language and then manually add
 
 .. _configuration_excluding_pages:
 
-Excluding pages
+Excluding Pages
 ^^^^^^^^^^^^^^^
 
 To exclude a set of pages, add each page's path to ``sitemap_exclude``:

--- a/docs/source/advanced-configuration.rst
+++ b/docs/source/advanced-configuration.rst
@@ -125,5 +125,12 @@ To generate the primary language with no alternatives, set :confval:`sitemap_loc
 
 For multilingual sitemaps, generate a sitemap per language and then manually add each to a `sitemapindex.xml`_ file.
 
+.. _configuration_excluding_pages:
+
+Excluding pages
+^^^^^^^^^^^^^^^
+
+Sometimes you want to exclude a set of pages.
+
 .. _sitemapindex.xml: https://support.google.com/webmasters/answer/75712?hl=en
 .. _sitemaps.org: https://www.sitemaps.org/protocol.html

--- a/docs/source/advanced-configuration.rst
+++ b/docs/source/advanced-configuration.rst
@@ -130,7 +130,15 @@ For multilingual sitemaps, generate a sitemap per language and then manually add
 Excluding pages
 ^^^^^^^^^^^^^^^
 
-Sometimes you want to exclude a set of pages.
+To exclude a set of pages, add each page's path to ``sitemap_exclude``:
+
+.. code-block:: python
+
+   sitemap_excludes = [
+       "search.html",
+       "genindex.html",
+   ]
+
 
 .. _sitemapindex.xml: https://support.google.com/webmasters/answer/75712?hl=en
 .. _sitemaps.org: https://www.sitemaps.org/protocol.html

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -115,10 +115,6 @@ ogp_image = "https://sphinx-sitemap.readthedocs.io/en/latest/_static/sitemap-ico
 
 html_baseurl = "https://sphinx-sitemap.readthedocs.org/"
 
-sitemap_excludes = [
-    "search.html",
-    "genindex.html",
-]
 
 # -- Options for HTMLHelp output ---------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -115,6 +115,11 @@ ogp_image = "https://sphinx-sitemap.readthedocs.io/en/latest/_static/sitemap-ico
 
 html_baseurl = "https://sphinx-sitemap.readthedocs.org/"
 
+sitemap_excludes = [
+    "search.html",
+    "genindex.html",
+]
+
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.

--- a/docs/source/configuration-values.rst
+++ b/docs/source/configuration-values.rst
@@ -3,12 +3,6 @@ Project Configuration Values
 
 A list of of possible configuration values to configure in **conf.py**:
 
-Another line to :math:`test two two`
-
-.. math::
-
-   test two two
-
 .. confval:: sitemap_url_scheme
 
    The scheme used for URL structure. Default is ``{lang}{version}{link}``.

--- a/docs/source/configuration-values.rst
+++ b/docs/source/configuration-values.rst
@@ -26,3 +26,11 @@ A list of of possible configuration values to configure in **conf.py**:
    See :ref:`configuration_supporting_multiple_languages` for more information.
 
    .. versionadded:: 2.2.0
+
+.. confval:: sitemap_excludes
+
+   The list of pages to exclude from the sitemap.
+
+   See :ref:`configuration_excluding_pages` for more information.
+
+   .. versionadded:: 2.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ maintainers = [
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Topic :: Documentation :: Sphinx",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/sphinx_sitemap/__init__.py
+++ b/sphinx_sitemap/__init__.py
@@ -42,6 +42,8 @@ def setup(app: Sphinx) -> Dict[str, Any]:
 
     app.add_config_value("sitemap_filename", default="sitemap.xml", rebuild="")
 
+    app.add_config_value("sitemap_excludes", default=[], rebuild="")
+
     try:
         app.add_config_value("html_baseurl", default=None, rebuild="")
     except BaseException:
@@ -143,7 +145,8 @@ def add_html_link(app: Sphinx, pagename: str, templatename, context, doctree):
     else:
         sitemap_link = pagename + file_suffix
 
-    env.app.sitemap_links.put(sitemap_link)  # type: ignore
+    if sitemap_link not in app.builder.config.sitemap_excludes:
+        env.app.sitemap_links.put(sitemap_link)  # type: ignore
 
 
 def create_sitemap(app: Sphinx, exception):

--- a/sphinx_sitemap/__init__.py
+++ b/sphinx_sitemap/__init__.py
@@ -21,7 +21,7 @@ from xml.etree import ElementTree
 from sphinx.application import Sphinx
 from sphinx.util.logging import getLogger
 
-__version__ = "2.5.1"
+__version__ = "2.6.0"
 
 logger = getLogger(__name__)
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -104,7 +104,11 @@ def test_simple_dirhtml(app, status, warning):
 @pytest.mark.sphinx(
     "html",
     freshenv=True,
-    confoverrides={"html_baseurl": "https://example.org/docs/", "language": "en", "sitemap_excludes": ["search.html", "genindex.html"]},
+    confoverrides={
+        "html_baseurl": "https://example.org/docs/",
+        "language": "en",
+        "sitemap_excludes": ["search.html", "genindex.html"],
+    },
 )
 def test_simple_excludes(app, status, warning):
     app.warningiserror = True

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -99,3 +99,32 @@ def test_simple_dirhtml(app, status, warning):
             "search/",
         ]
     }
+
+
+@pytest.mark.sphinx(
+    "html",
+    freshenv=True,
+    confoverrides={"html_baseurl": "https://example.org/docs/", "language": "en", "sitemap_excludes": ["search.html", "genindex.html"]},
+)
+def test_simple_excludes(app, status, warning):
+    app.warningiserror = True
+    app.build()
+    assert "sitemap.xml" in os.listdir(app.outdir)
+    doc = etree.parse(app.outdir / "sitemap.xml")
+    urls = {
+        e.text
+        for e in doc.findall(".//{http://www.sitemaps.org/schemas/sitemap/0.9}loc")
+    }
+
+    assert urls == {
+        f"https://example.org/docs/en/{d}.html"
+        for d in [
+            "index",
+            "foo",
+            "bar",
+            "lorem",
+            "ipsum",
+            "dolor",
+            "elitr",
+        ]
+    }

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     sphinx7: Sphinx~=7.0
     sphinxlast: Sphinx
 commands =
-    pytest -v
+    pytest
 
 [flake8]
 max-line-length = 100

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     sphinx7: Sphinx~=7.0
     sphinxlast: Sphinx
 commands =
-    pytest -W ignore::DeprecationWarning
+    pytest -v
 
 [flake8]
 max-line-length = 100

--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,9 @@ envlist =
 [testenv]
 deps =
     pytest
-    defusedxml
-    sphinx5: Sphinx~=5.0
-    sphinx6: Sphinx~=6.0
-    sphinx7: Sphinx~=7.0
+    sphinx5: Sphinx[test]~=5.0
+    sphinx6: Sphinx[test]~=6.0
+    sphinx7: Sphinx[test]~=7.0
     sphinxlast: Sphinx
 commands =
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     py3{8,9}-sphinx{5,6,7,last}
     # Python 3.10 is unsupported below Sphinx4
     # See https://github.com/sphinx-doc/sphinx/issues/9816
-    py3{10,11}-sphinx{5,6,7,last}
+    py3{10,11,12}-sphinx{5,6,7,last}
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,16 @@
 [tox]
 envlist =
-    py37-sphinx5
-    # Python 3.7 unsupported above Sphinx 6
-    py3{8,9}-sphinx{5,6,last}
+    py3{8,9}-sphinx{5,6,7,last}
     # Python 3.10 is unsupported below Sphinx4
     # See https://github.com/sphinx-doc/sphinx/issues/9816
-    py3{10,11}-sphinx{5,6,last}
+    py3{10,11}-sphinx{5,6,7,last}
 
 [testenv]
 deps =
     pytest
     sphinx5: Sphinx~=5.0
     sphinx6: Sphinx~=6.0
+    sphinx7: Sphinx~=7.0
     sphinxlast: Sphinx
 commands =
     pytest -W ignore::DeprecationWarning

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,9 @@ deps =
     sphinx5: Sphinx[test]~=5.0
     sphinx6: Sphinx[test]~=6.0
     sphinx7: Sphinx[test]~=7.0
-    sphinxlast: Sphinx
+    sphinxlast: Sphinx[test]
 commands =
-    pytest
+    pytest -W ignore::DeprecationWarning
 
 [flake8]
 max-line-length = 100

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
 [testenv]
 deps =
     pytest
+    defusedxml
     sphinx5: Sphinx~=5.0
     sphinx6: Sphinx~=6.0
     sphinx7: Sphinx~=7.0


### PR DESCRIPTION
Fixes https://github.com/jdillard/sphinx-sitemap/issues/2

## Summary of changes

- Add `sitemap_excludes` config option (including docs and tests)
- Drop testing support for Python 3.7 and add support for 3.12
- Fix existing tox testing errors for Sphinx 7

## Built docs

- https://sphinx-sitemap--91.org.readthedocs.build/en/91/