### PR TITLE
Add `sitemap_excludes` config

### DIFF
--- a/docs/source/advanced-configuration.rst
+++ b/docs/source/advanced-configuration.rst
@@ -39,6 +39,15 @@ Set :confval:`sitemap_filename` in **conf.py** to the desired filename, for exam
 
    sitemap_filename = "sitemap.xml"
 
+Excluding Pages
+^^^^^^^^^^^^^^^
+
+Set :confval:`sitemap_excludes` in **conf.py** to exclude some pages, for example:
+
+.. code-block:: python
+
+   sitemap_excludes = ["404"]
+
 Version Support
 ^^^^^^^^^^^^^^^
 

--- a/sphinx_sitemap/__init__.py
+++ b/sphinx_sitemap/__init__.py
@@ -42,6 +42,8 @@ def setup(app: Sphinx) -> Dict[str, Any]:
 
     app.add_config_value("sitemap_filename", default="sitemap.xml", rebuild="")
 
+    app.add_config_value("sitemap_excludes", default=None, rebuild="")
+
     try:
         app.add_config_value("html_baseurl", default=None, rebuild="")
     except BaseException:
@@ -125,6 +127,9 @@ def add_html_link(app: Sphinx, pagename: str, templatename, context, doctree):
     :param app: The Sphinx Application instance
     :param pagename: The current page being built
     """
+    if app.config.sitemap_excludes and pagename in app.config.sitemap_excludes:
+        return
+
     env = app.builder.env
     if app.builder.config.html_file_suffix is None:
         file_suffix = ".html"


### PR DESCRIPTION
This configure is used to exclude some certain pages, for example: 404, 500.

Here is a real case:

https://shibuya.lepture.com/customisation/layouts/#layout

https://shibuya.lepture.com/sitemap.xml
