### PR TITLE
Add configuration option `sitemap_lastmod`

### DIFF
--- a/docs/source/advanced-configuration.rst
+++ b/docs/source/advanced-configuration.rst
@@ -139,6 +139,19 @@ To exclude a set of pages, add each page's path to ``sitemap_exclude``:
        "genindex.html",
    ]
 
+.. _configuration_lastmod:
+
+Adding Last Modification Date
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To add the date of the last page modification set ``sitemap_lastmod`` to either ``True``, or a string representating
+the last modification date.
+
+.. code-block:: python
+
+   sitemap_lastmod = True
+   # or
+   sitemap_lastmod = "2024-08-13"
 
 .. _sitemapindex.xml: https://support.google.com/webmasters/answer/75712?hl=en
 .. _sitemaps.org: https://www.sitemaps.org/protocol.html

--- a/docs/source/configuration-values.rst
+++ b/docs/source/configuration-values.rst
@@ -34,3 +34,11 @@ A list of of possible configuration values to configure in **conf.py**:
    See :ref:`configuration_excluding_pages` for more information.
 
    .. versionadded:: 2.6.0
+
+.. confval:: sitemap_lastmod
+
+   The entry ``lastmod`` is added to the output file.
+
+   See :ref:`configuration_lastmod` for more information.
+
+   .. versionadded:: 2.7.0

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -68,12 +68,21 @@ def test_html_file_suffix(app, status, warning):
             "search",
         ]
     }
+    lastmod = [
+        e.text
+        for e in doc.findall(".//{http://www.sitemaps.org/schemas/sitemap/0.9}lastmod")
+    ]
+    assert not lastmod
 
 
 @pytest.mark.sphinx(
     "dirhtml",
     freshenv=True,
-    confoverrides={"html_baseurl": "https://example.org/docs/", "language": "en"},
+    confoverrides={
+        "html_baseurl": "https://example.org/docs/",
+        "language": "en",
+        "sitemap_lastmod": True,
+    },
 )
 def test_simple_dirhtml(app, status, warning):
     app.warningiserror = True
@@ -99,6 +108,11 @@ def test_simple_dirhtml(app, status, warning):
             "search/",
         ]
     }
+    lastmod = [
+        e.text
+        for e in doc.findall(".//{http://www.sitemaps.org/schemas/sitemap/0.9}lastmod")
+    ]
+    assert len(lastmod) == len(urls)
 
 
 @pytest.mark.sphinx(
@@ -108,6 +122,7 @@ def test_simple_dirhtml(app, status, warning):
         "html_baseurl": "https://example.org/docs/",
         "language": "en",
         "sitemap_excludes": ["search.html", "genindex.html"],
+        "sitemap_lastmod": "2024-08-13",
     },
 )
 def test_simple_excludes(app, status, warning):
@@ -131,4 +146,15 @@ def test_simple_excludes(app, status, warning):
             "dolor",
             "elitr",
         ]
+    }
+
+    lastmod = [
+        e.text
+        for e in doc.findall(".//{http://www.sitemaps.org/schemas/sitemap/0.9}lastmod")
+    ]
+
+    assert len(lastmod) == len(urls)
+
+    assert set(lastmod) == {
+        app.builder.config.sitemap_lastmod,
     }

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     sphinx7: Sphinx[test]~=7.0
     sphinxlast: Sphinx[test]
 commands =
-    pytest -W ignore::DeprecationWarning
+    pytest -W ignore::DeprecationWarning {posargs}
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
I added a configuration option to generate `lastmod` entries for the urls.

The Option can either be set to `True` (current date is used) or a string with the desired lastmod date.

I introduced another small patch in adding {posargs} to the pytest call in `tox.ini`, which allows specifying additional command line options for the `pytest` call when starting `tox` .