### PR TITLE
Add a configuration value to indent the output (aka prettify output)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@
 Changelog
 =========
 
+2.9.0
+-----
+
+- |:sparkles:| NEW: Add :confval:`sitemap_indent` configuration value to control XML indentation
+  `#112 <https://github.com/jdillard/sphinx-sitemap/pull/112>`_
+
 2.8.0
 -----
 

--- a/docs/source/advanced-configuration.rst
+++ b/docs/source/advanced-configuration.rst
@@ -181,19 +181,19 @@ This produces sitemap entries like:
 .. _sitemapindex.xml: https://support.google.com/webmasters/answer/75712?hl=en
 .. _sitemaps.org: https://www.sitemaps.org/protocol.html
 
-.. _configuration_prettify:
+.. _configuration_indent:
 
-Prettify
-^^^^^^^^
+Formatting XML Output
+^^^^^^^^^^^^^^^^^^^^^
 
-To enable prettified output, set :confval:`sitemap_prettify` to ``True`` in **conf.py**:
-
-.. code-block:: python
-
-   sitemap_prettify = True
-
-If :confval:`sitemap_prettify` is set to an integer, indentation will be set to this number of spaces:
+To add indention to the XML output, set :confval:`sitemap_indent` to the number of spaces for indentation in **conf.py**:
 
 .. code-block:: python
 
-   sitemap_prettify = 2
+   sitemap_indent = 2
+
+Set to ``0`` (the default) to disable indentation:
+
+.. code-block:: python
+
+   sitemap_indent = 0

--- a/docs/source/configuration-values.rst
+++ b/docs/source/configuration-values.rst
@@ -51,3 +51,12 @@ A list of of possible configuration values to configure in **conf.py**:
      See :ref:`configuration_lastmod` for more information.
 
    .. versionadded:: 2.7.0
+
+.. confval:: sitemap_indent
+
+   - **Type**: integer
+   - **Default**: ``0``
+   - **Description**: Number of spaces to use for indentation in the sitemap XML output.
+     See :ref:`configuration_indent` for more information.
+
+   .. versionadded:: 2.9.0

--- a/sphinx_sitemap/__init__.py
+++ b/sphinx_sitemap/__init__.py
@@ -24,7 +24,7 @@ from sphinx.application import Sphinx
 from sphinx.errors import ExtensionError
 from sphinx.util.logging import getLogger
 
-__version__ = "2.8.0"
+__version__ = "2.9.0"
 
 logger = getLogger(__name__)
 
@@ -49,7 +49,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
 
     app.add_config_value("sitemap_show_lastmod", default=False, rebuild="")
 
-    app.add_config_value("sitemap_prettify", default=False, rebuild="")
+    app.add_config_value("sitemap_indent", default=0, rebuild="")
 
     try:
         app.add_config_value("html_baseurl", default=None, rebuild="")
@@ -260,13 +260,8 @@ def create_sitemap(app: Sphinx, exception):
             )
 
     filename = Path(app.outdir) / app.config.sitemap_filename
-    if app.config.sitemap_prettify not in [None, False]:
-        indentation = app.config.sitemap_prettify
-        if indentation is True:
-            indentation = 2 * " "
-        else:
-            indentation = int(indentation) * " "
-        ElementTree.indent(root, space=indentation)
+    if isinstance(app.config.sitemap_indent, int) and app.config.sitemap_indent > 0:
+        ElementTree.indent(root, space=app.config.sitemap_indent * " ")
 
     ElementTree.ElementTree(root).write(
         filename, xml_declaration=True, encoding="utf-8", method="xml"

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -223,10 +223,10 @@ def test_pattern_excludes(app, status, warning):
     confoverrides={
         "html_baseurl": "https://example.org/docs/",
         "language": "en",
-        "sitemap_prettify": True,
+        "sitemap_indent": 2,
     },
 )
-def test_prettify(app, status, warning):
+def test_indent(app, status, warning):
     """Tests that xml output is indented"""
     app.warningiserror = True
     app.build()


### PR DESCRIPTION
This MR adds prettified output to the plugin.

It's off by default, to keep backward compatibility.

By setting `sitemap_prettify`, it will be enabled. By setting `sitemap_prettify` to an int, it will use that int for how many spaces to use as indentation.

This MR would close https://github.com/jdillard/sphinx-sitemap/issues/101